### PR TITLE
Fix Issue #1: Use ProcessPoolExecutor instead of ThreadPoolExecutor

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -445,7 +445,7 @@ def record(
     # Using `with` to exist smoothly if an execption is raised.
     futures = []
     num_image_writers = num_image_writers_per_camera * len(robot.cameras)
-    with concurrent.futures.ThreadPoolExecutor(max_workers=num_image_writers) as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=num_image_writers) as executor:
         # Start recording all episodes
         while episode_index < num_episodes:
             logging.info(f"Recording episode {episode_index}")


### PR DESCRIPTION
|  Title               | Label           |
|----------------------|-----------------|
| Fixes #1     | (🐛 Bug)        |
| Used ProcessPoolExecutor instead of the ThreadPoolExecutor for saving images to disk during the evaluation. ProcessPoolExecutor bypasses GIL thereby improving the performance for I/O operations. | When the evaluation is run on a 4 camera setup using the Aloha Kit, the frequency drops to 7-8 Hz which is lower than the expected 30 Hz. |

## How it was tested
Run the evaluation script you should see a improvement in the performance and the robots moving smoothly to complete the task.

- Changed `ThreadPoolExecutors` to `ProcessPoolExecutors`   in  `lerobot/scripts/control_robot.py`.


```bash
python lerobot/scripts/control_robot.py record \
  --robot-path lerobot/configs/robot/aloha.yaml \
  --fps 30 \
  --root data \
  --repo-id ${HF_USER}/eval_aloha_test \
  --tags tutorial eval \
  --warmup-time-s 5 \
  --episode-time-s 30 \
  --reset-time-s 30 \
  --num-episodes 10 \
  -p ${HF_USER}/act_aloha_test
```

