### PR TITLE
Fix Issue 2: Reduced the batch size and num_workers for computing stats.

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -664,7 +664,7 @@ def record(
     if run_compute_stats:
         logging.info("Computing dataset statistics")
         say("Computing dataset statistics")
-        stats = compute_stats(lerobot_dataset)
+        stats = compute_stats(lerobot_dataset, batch_size=8, num_workers=4)
         lerobot_dataset.stats = stats
     else:
         stats = {}


### PR DESCRIPTION
## What this does
|  Title               | Label           |
|----------------------|-----------------|
| Fixes #2     | (🐛 Bug)        |
| Reduce the batch size and workers used for computing dataset stats. | The code crashes while computing the dataset statistics on low performance systems.|

Run the `lerobot/scripts/control_robot.py` script. You will notice the program no longer crashes and completes the execution.

- Reduced `batch_size` and `num_workers` in `lerobot/scripts/control_robot.py`.

Run the below command to test the changes.

Examples:
```bash
python lerobot/scripts/control_robot.py record \
   --robot-path lerobot/configs/robot/aloha.yaml \
   --fps 30 \
   --root data \
   --repo-id ${HF_USER}/aloha_test \
   --tags tutorial \
   --warmup-time-s 5 \
   --episode-time-s 30 \
   --reset-time-s 30 \
   --num-episodes 2
```
