### PR TITLE
Feature Update: Allow Teleop to reset arms

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -583,8 +583,19 @@ def record(
 
             # Wait if necessary
             with tqdm.tqdm(total=reset_time_s, desc="Waiting") as pbar:
+
+                if not robot.is_connected:
+                    robot.connect()
+
                 while timestamp < reset_time_s and not is_last_episode:
-                    time.sleep(1)
+                    start_loop_t = time.perf_counter()
+                    robot.teleop_step()
+
+                    if fps is not None:
+                        dt_s = time.perf_counter() - start_loop_t
+                        busy_wait(1 / fps - dt_s)
+
+                    dt_s = time.perf_counter() - start_loop_t
                     timestamp = time.perf_counter() - start_vencod_t
                     pbar.update(1)
                     if exit_early:


### PR DESCRIPTION

Examples:
|  Title               | Label           |
|----------------------|-----------------|
| Feature Update  | (⚡️ Performance) |
| Allow Resetting the Arms to desired position using Teleop|

Run the `lerobot/scripts/control_robot.py` script.

- Added `teleoperation` in `lerobot/scripts/control_robot.py`.
- You should be able to move the arms to a desired position while in rest mode.


Examples:
```bash
python lerobot/scripts/control_robot.py record \
   --robot-path lerobot/configs/robot/aloha.yaml \
   --fps 30 \
   --root data \
   --repo-id ${HF_USER}/aloha_test \
   --tags tutorial \
   --warmup-time-s 5 \
   --episode-time-s 30 \
   --reset-time-s 30 \
   --num-episodes 2
```

