### PR TITLE
Add Explicit Support for OpenCV

### DIFF
--- a/lerobot/common/robot_devices/robots/configs.py
+++ b/lerobot/common/robot_devices/robots/configs.py
@@ -15,6 +15,7 @@
 import abc
 from dataclasses import dataclass, field
 from typing import Sequence
+from typing import Literal
 
 import draccus
 
@@ -634,8 +635,7 @@ class TrossenAIStationaryRobotConfig(ManipulatorRobotConfig):
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
 
-    camera_interface: str = 'intel_realsense'
-    # camera_interface: str = 'opencv'
+    camera_interface: Literal["intel_realsense", "opencv"] = "intel_realsense"
 
     leader_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
@@ -665,11 +665,7 @@ class TrossenAIStationaryRobotConfig(ManipulatorRobotConfig):
         }
     )
 
-    # Troubleshooting: If one of your IntelRealSense cameras freeze during
-    # data recording due to bandwidth limit, you might need to plug the camera
-    # on another USB hub or PCIe card.
-
-    if camera_interface == 'opencv':
+    if camera_interface == "opencv":
         cameras: dict[str, CameraConfig] = field(
             default_factory=lambda: {
                 "cam_high": OpenCVCameraConfig(
@@ -698,8 +694,10 @@ class TrossenAIStationaryRobotConfig(ManipulatorRobotConfig):
                 ),
             }
         )
-    elif camera_interface == 'intel_realsense':
-        # 218622274938, 130322272628, 128422271347, 218622270304
+    elif camera_interface == "intel_realsense":
+        # Troubleshooting: If one of your IntelRealSense cameras freeze during
+        # data recording due to bandwidth limit, you might need to plug the camera
+        # on another USB hub or PCIe card.
         cameras: dict[str, CameraConfig] = field(
             default_factory=lambda: {
                 "cam_high": IntelRealSenseCameraConfig(
@@ -729,7 +727,9 @@ class TrossenAIStationaryRobotConfig(ManipulatorRobotConfig):
             }
         )
     else:
-        raise ValueError(f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'.")
+        raise ValueError(
+            f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'."
+        )
 
     mock: bool = False
 
@@ -753,10 +753,8 @@ class TrossenAISoloRobotConfig(ManipulatorRobotConfig):
     # This enables the user to feel external forces (e.g., contact with objects) through force feedback.
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
-  
-    # Set the camera interface to use. Options are 'opencv' or 'intel_realsense'.
-    camera_interface: str = 'intel_realsense'
-    # camera_interface: str = 'opencv'
+
+    camera_interface: Literal["intel_realsense", "opencv"] = "intel_realsense"
 
     leader_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
@@ -777,7 +775,7 @@ class TrossenAISoloRobotConfig(ManipulatorRobotConfig):
         }
     )
 
-    if camera_interface == 'opencv':
+    if camera_interface == "opencv":
         cameras: dict[str, CameraConfig] = field(
             default_factory=lambda: {
                 "cam_main": OpenCVCameraConfig(
@@ -794,7 +792,7 @@ class TrossenAISoloRobotConfig(ManipulatorRobotConfig):
                 ),
             }
         )
-    elif camera_interface == 'intel_realsense':  
+    elif camera_interface == "intel_realsense":
         # Troubleshooting: If one of your IntelRealSense cameras freeze during
         # data recording due to bandwidth limit, you might need to plug the camera
         # on another USB hub or PCIe card.
@@ -815,8 +813,10 @@ class TrossenAISoloRobotConfig(ManipulatorRobotConfig):
             }
         )
     else:
-        raise ValueError(f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'.")
-    
+        raise ValueError(
+            f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'."
+        )
+
     mock: bool = False
 
 
@@ -839,9 +839,8 @@ class TrossenAIMobileRobotConfig(RobotConfig):
     # This enables the user to feel external forces (e.g., contact with objects) through force feedback.
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
-    
-    camera_interface: str = 'intel_realsense'
-    # camera_interface: str = 'opencv'
+
+    camera_interface: Literal["intel_realsense", "opencv"] = "intel_realsense"
 
     enable_motor_torque: bool = False
 
@@ -873,7 +872,7 @@ class TrossenAIMobileRobotConfig(RobotConfig):
         }
     )
 
-    if camera_interface == 'opencv':
+    if camera_interface == "opencv":
         cameras: dict[str, CameraConfig] = field(
             default_factory=lambda: {
                 "cam_high": OpenCVCameraConfig(
@@ -896,7 +895,7 @@ class TrossenAIMobileRobotConfig(RobotConfig):
                 ),
             }
         )
-    elif camera_interface == 'intel_realsense':
+    elif camera_interface == "intel_realsense":
         # Troubleshooting: If one of your IntelRealSense cameras freeze during
         # data recording due to bandwidth limit, you might need to plug the camera
         # on another USB hub or PCIe card.
@@ -923,6 +922,8 @@ class TrossenAIMobileRobotConfig(RobotConfig):
             }
         )
     else:
-        raise ValueError(f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'.")
+        raise ValueError(
+            f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'."
+        )
 
     mock: bool = False

--- a/lerobot/common/robot_devices/robots/configs.py
+++ b/lerobot/common/robot_devices/robots/configs.py
@@ -14,8 +14,7 @@
 
 import abc
 from dataclasses import dataclass, field
-from typing import Sequence
-from typing import Literal
+from typing import Literal, Sequence
 
 import draccus
 
@@ -635,6 +634,9 @@ class TrossenAIStationaryRobotConfig(ManipulatorRobotConfig):
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
 
+    # Set this according to the camera interface you want to use.
+    # "intel_realsense" is the default and recommended option.
+    # "opencv" is a fallback option that uses OpenCV to access the cameras.
     camera_interface: Literal["intel_realsense", "opencv"] = "intel_realsense"
 
     leader_arms: dict[str, MotorsBusConfig] = field(
@@ -754,6 +756,9 @@ class TrossenAISoloRobotConfig(ManipulatorRobotConfig):
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
 
+    # Set this according to the camera interface you want to use.
+    # "intel_realsense" is the default and recommended option.
+    # "opencv" is a fallback option that uses OpenCV to access the cameras.
     camera_interface: Literal["intel_realsense", "opencv"] = "intel_realsense"
 
     leader_arms: dict[str, MotorsBusConfig] = field(
@@ -840,6 +845,9 @@ class TrossenAIMobileRobotConfig(RobotConfig):
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
 
+    # Set this according to the camera interface you want to use.
+    # "intel_realsense" is the default and recommended option.
+    # "opencv" is a fallback option that uses OpenCV to access the cameras.
     camera_interface: Literal["intel_realsense", "opencv"] = "intel_realsense"
 
     enable_motor_torque: bool = False

--- a/lerobot/common/robot_devices/robots/configs.py
+++ b/lerobot/common/robot_devices/robots/configs.py
@@ -634,6 +634,9 @@ class TrossenAIStationaryRobotConfig(ManipulatorRobotConfig):
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
 
+    camera_interface: str = 'intel_realsense'
+    # camera_interface: str = 'opencv'
+
     leader_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
             "left": TrossenArmDriverConfig(
@@ -665,34 +668,68 @@ class TrossenAIStationaryRobotConfig(ManipulatorRobotConfig):
     # Troubleshooting: If one of your IntelRealSense cameras freeze during
     # data recording due to bandwidth limit, you might need to plug the camera
     # on another USB hub or PCIe card.
-    cameras: dict[str, CameraConfig] = field(
-        default_factory=lambda: {
-            "cam_high": IntelRealSenseCameraConfig(
-                serial_number=130322270184,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-            "cam_low": IntelRealSenseCameraConfig(
-                serial_number=130322270184,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-            "cam_left_wrist": IntelRealSenseCameraConfig(
-                serial_number=218622274938,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-            "cam_right_wrist": IntelRealSenseCameraConfig(
-                serial_number=128422271347,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-        }
-    )
+
+    if camera_interface == 'opencv':
+        cameras: dict[str, CameraConfig] = field(
+            default_factory=lambda: {
+                "cam_high": OpenCVCameraConfig(
+                    camera_index=26,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_low": OpenCVCameraConfig(
+                    camera_index=14,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_left_wrist": OpenCVCameraConfig(
+                    camera_index=8,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_right_wrist": OpenCVCameraConfig(
+                    camera_index=20,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+            }
+        )
+    elif camera_interface == 'intel_realsense':
+        # 218622274938, 130322272628, 128422271347, 218622270304
+        cameras: dict[str, CameraConfig] = field(
+            default_factory=lambda: {
+                "cam_high": IntelRealSenseCameraConfig(
+                    serial_number=218622274938,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_low": IntelRealSenseCameraConfig(
+                    serial_number=130322272628,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_left_wrist": IntelRealSenseCameraConfig(
+                    serial_number=128422271347,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_right_wrist": IntelRealSenseCameraConfig(
+                    serial_number=218622270304,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+            }
+        )
+    else:
+        raise ValueError(f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'.")
 
     mock: bool = False
 
@@ -716,6 +753,10 @@ class TrossenAISoloRobotConfig(ManipulatorRobotConfig):
     # This enables the user to feel external forces (e.g., contact with objects) through force feedback.
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
+  
+    # Set the camera interface to use. Options are 'opencv' or 'intel_realsense'.
+    camera_interface: str = 'intel_realsense'
+    # camera_interface: str = 'opencv'
 
     leader_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
@@ -736,26 +777,46 @@ class TrossenAISoloRobotConfig(ManipulatorRobotConfig):
         }
     )
 
-    # Troubleshooting: If one of your IntelRealSense cameras freeze during
-    # data recording due to bandwidth limit, you might need to plug the camera
-    # on another USB hub or PCIe card.
-    cameras: dict[str, CameraConfig] = field(
-        default_factory=lambda: {
-            "cam_high": IntelRealSenseCameraConfig(
-                serial_number=130322270184,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-            "cam_wrist": IntelRealSenseCameraConfig(
-                serial_number=218622274938,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-        }
-    )
-
+    if camera_interface == 'opencv':
+        cameras: dict[str, CameraConfig] = field(
+            default_factory=lambda: {
+                "cam_main": OpenCVCameraConfig(
+                    camera_index=26,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_wrist": OpenCVCameraConfig(
+                    camera_index=8,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+            }
+        )
+    elif camera_interface == 'intel_realsense':  
+        # Troubleshooting: If one of your IntelRealSense cameras freeze during
+        # data recording due to bandwidth limit, you might need to plug the camera
+        # on another USB hub or PCIe card.
+        cameras: dict[str, CameraConfig] = field(
+            default_factory=lambda: {
+                "cam_main": IntelRealSenseCameraConfig(
+                    serial_number=130322270184,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_wrist": IntelRealSenseCameraConfig(
+                    serial_number=218622274938,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+            }
+        )
+    else:
+        raise ValueError(f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'.")
+    
     mock: bool = False
 
 
@@ -778,6 +839,9 @@ class TrossenAIMobileRobotConfig(RobotConfig):
     # This enables the user to feel external forces (e.g., contact with objects) through force feedback.
     # A value of 0.0 disables force feedback. A good starting value for a responsive experience is 0.1.
     force_feedback_gain: float = 0.0
+    
+    camera_interface: str = 'intel_realsense'
+    # camera_interface: str = 'opencv'
 
     enable_motor_torque: bool = False
 
@@ -809,30 +873,56 @@ class TrossenAIMobileRobotConfig(RobotConfig):
         }
     )
 
-    # Troubleshooting: If one of your IntelRealSense cameras freeze during
-    # data recording due to bandwidth limit, you might need to plug the camera
-    # on another USB hub or PCIe card.
-    cameras: dict[str, CameraConfig] = field(
-        default_factory=lambda: {
-            "cam_high": IntelRealSenseCameraConfig(
-                serial_number=130322270184,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-            "cam_left_wrist": IntelRealSenseCameraConfig(
-                serial_number=218622274938,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-            "cam_right_wrist": IntelRealSenseCameraConfig(
-                serial_number=128422271347,
-                fps=30,
-                width=640,
-                height=480,
-            ),
-        }
-    )
+    if camera_interface == 'opencv':
+        cameras: dict[str, CameraConfig] = field(
+            default_factory=lambda: {
+                "cam_high": OpenCVCameraConfig(
+                    camera_index=26,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_left_wrist": OpenCVCameraConfig(
+                    camera_index=8,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_right_wrist": OpenCVCameraConfig(
+                    camera_index=20,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+            }
+        )
+    elif camera_interface == 'intel_realsense':
+        # Troubleshooting: If one of your IntelRealSense cameras freeze during
+        # data recording due to bandwidth limit, you might need to plug the camera
+        # on another USB hub or PCIe card.
+        cameras: dict[str, CameraConfig] = field(
+            default_factory=lambda: {
+                "cam_high": IntelRealSenseCameraConfig(
+                    serial_number=130322270184,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_left_wrist": IntelRealSenseCameraConfig(
+                    serial_number=218622274938,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+                "cam_right_wrist": IntelRealSenseCameraConfig(
+                    serial_number=128422271347,
+                    fps=30,
+                    width=640,
+                    height=480,
+                ),
+            }
+        )
+    else:
+        raise ValueError(f"Unknown camera interface: {camera_interface}. Supported values are 'opencv' and 'intel_realsense'.")
 
     mock: bool = False

--- a/lerobot/common/robot_devices/robots/manipulator.py
+++ b/lerobot/common/robot_devices/robots/manipulator.py
@@ -461,7 +461,9 @@ class ManipulatorRobot:
             self.follower_arms[name].write("Acceleration", 254)
 
     def teleop_step(
-        self, record_data=False, record_joint_angles=True,
+        self,
+        record_data=False,
+        record_joint_angles=True,
     ) -> None | tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
         if not self.is_connected:
             raise RobotDeviceNotConnectedError(

--- a/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
+++ b/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
@@ -197,7 +197,9 @@ class TrossenAIMobile:
         }
 
     def teleop_step(
-        self, record_data=False, record_joint_angles=True,
+        self,
+        record_data=False,
+        record_joint_angles=True,
     ) -> None | tuple[dict[str, torch.Tensor], dict[str, torch.Tensor]]:
         if not self.is_connected:
             raise RobotDeviceNotConnectedError(


### PR DESCRIPTION
## What this does

1. Provides easy to setup interface for alternating between Open CV and Intelrealsense for using cameras.
2. User's can change the interface using `robot.camera_interface` argument from command line.

Example:
```bash
python lerobot/scripts/control_robot.py   --robot.type=trossen_ai_stationary   --robot.max_relative_target=null   --control.type=teleoperate --robot.camera_interface=intel_realsense
```

```bash
python lerobot/scripts/control_robot.py   --robot.type=trossen_ai_stationary   --robot.max_relative_target=null   --control.type=teleoperate --robot.camera_interface=opencv
```