### PR TITLE
Fix: Reset Temporal Ensemble Buffer Between Episodes

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -282,6 +282,9 @@ def control_loop(
             events["exit_early"] = False
             break
 
+        if policy is not None:
+            policy.reset()
+
 
 def reset_environment(robot, events, reset_time_s, fps):
     # TODO(rcadene): refactor warmup_record and reset_environment


### PR DESCRIPTION
When temporal ensembling is enabled during inference, actions are accumulated over time in a buffer to improve stability and robustness. However, this accumulation persists across episode resets, causing actions from previous episodes to undesirably influence the robot's behavior in newly recorded episodes—even when the scene has been reset.

To address this, we now reset the policy (and hence the temporal ensemble buffer) at the end of each episode. This ensures that action predictions are based solely on the current context, and not influenced by stale temporal information from prior episodes.