### PR TITLE
Remove `Backward Compatibility Check` for Dataset Updates/Conversion

### DIFF
--- a/lerobot/scripts/convert_dataset_v21_to_v21_t10.py
+++ b/lerobot/scripts/convert_dataset_v21_to_v21_t10.py
@@ -127,6 +127,7 @@ class DatasetModifier:
                 repo_id=self.repo_id,
                 root=self.root if self.root != HF_LEROBOT_HOME else None,
                 episodes=[episode_index],
+                edit_mode=True,
             )
 
             modified_actions = []


### PR DESCRIPTION
The enforcement of backward compatibility check doesn't allow datasets to be loaded in the conversion script. The conversion script should be able to load old datasets to make changes.

Added `edit_mode` to the `LeRobotDataset` and `LeRobotDatasetMetadata` class. Making this `True` when editing the dataset allows to bypass the version check. 

This can also be used in future for any custom updates or conversion in the datasets. Like adding intrinsic/extrinsic parameters to metadata.