### PR TITLE
Fix type mismatch in `set_all_external_efforts` by converting NumPy array to Python list

### DIFF
--- a/lerobot/common/robot_devices/motors/trossen_arm_driver.py
+++ b/lerobot/common/robot_devices/motors/trossen_arm_driver.py
@@ -218,7 +218,7 @@ class TrossenArmDriver:
             self.driver.set_all_modes(trossen.Mode.position)
             self.driver.set_all_positions(self.home_pose, 2.0, False)
         elif data_name == "External_Efforts":
-            self.driver.set_all_external_efforts(values, 0.0, False)
+            self.driver.set_all_external_efforts(values.tolist(), 0.0, False)
         else:
             print(f"Data name: {data_name} value: {values} is not supported for writing.")
 


### PR DESCRIPTION
This PR fixes a TypeError encountered when calling set_all_external_efforts with a NumPy array. The function expects a VectorDouble (mapped to std::vector<double> via PyBind11), but was being passed a NumPy array directly.

The fix converts the `NumPy` array to a native Python list using `.tolist()`, which is compatible with `PyBind11` and resolves the type mismatch:

```python
values.tolist()  # ensures proper conversion to VectorDouble
```