### PR TITLE
Improve logging for mobile base and prevent segmentation fault on uninitialized base

### DIFF
--- a/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
+++ b/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
@@ -115,7 +115,7 @@ class TrossenAIMobile:
         success, result = self.base.init_base()
         if not success:
             raise RobotDeviceNotConnectedError(
-                f"{result}.\nMake sure the robot is powered on and connected to the computer.\n{self.check_base_state()[0]}"
+                f"{result}.\nMake sure the robot is powered on and connected to the computer."
             )
         try:
             if self.check_base_state()[1] == SlateBaseSystemState.SYS_ESTOP:


### PR DESCRIPTION
This PR enhances logging behavior for the mobile base. Previously, calling `check_status()` when the base was uninitialized could result in a segmentation fault. To avoid this crash and improve clarity, the `check_status()` call has been removed from the log message, ensuring safe and meaningful logging even when the base is not initialized.