### PR TITLE
Fix inference issue on Trossen AI Mobile

### DIFF
--- a/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
+++ b/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
@@ -309,7 +309,7 @@ class TrossenAIMobile:
         for name in self.follower_arms:
             if name in follower_pos:
                 state.append(follower_pos[name])
-        state.append(base_state.values())
+        state.append(torch.as_tensor(list(base_state.values())))
         state = torch.cat(state)
 
         # Capture images from cameras
@@ -326,9 +326,6 @@ class TrossenAIMobile:
         obs_dict["observation.state"] = state
         for name in self.cameras:
             obs_dict[f"observation.images.{name}"] = images[name]
-
-        obs_dict = {}
-        obs_dict["observation.state"] = state
 
         return obs_dict
 


### PR DESCRIPTION
1. Replaced `state.append(base_state.values())` with `state.append(torch.as_tensor(list(base_state.values())))` to ensure proper tensor conversion during inference.
2. Removed unused `obs_dict["observation.state"] = state` assignment to avoid redundant or incorrect state packaging.