### PR TITLE
Disable leader arms during evaluation and trajectory replay

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -269,6 +269,11 @@ def record(
     # Load pretrained policy
     policy = None if cfg.policy is None else make_policy(cfg.policy, ds_meta=dataset.meta)
 
+    # Disable the leader arms if a policy is provided,
+    # as they are not used during evaluation.
+    if policy is not None:
+        robot.leader_arms = []
+
     if not robot.is_connected:
         robot.connect()
 
@@ -345,6 +350,9 @@ def replay(
 
     dataset = LeRobotDataset(cfg.repo_id, root=cfg.root, episodes=[cfg.episode])
     actions = dataset.hf_dataset.select_columns("action")
+
+    # Disable leader arms as they are not used during replay
+    robot.leader_arms = []
 
     if not robot.is_connected:
         robot.connect()


### PR DESCRIPTION
* Disables `leader_arms` on the robot during evaluation (`record()`) and trajectory replay (`replay()`) when they are not required.
* This helps prevent unnecessary control overhead or unintended movement on the leader arms during policy execution or playback.
* During evaluation: `leader_arms` are removed if a policy is provided.
* During replay: `leader_arms` are always removed, as only the follower arms are needed to mimic the saved trajectory.
