### PR TITLE
Fix policy.reset() indentation to occur at end of each episode

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -282,8 +282,8 @@ def control_loop(
             events["exit_early"] = False
             break
 
-        if policy is not None:
-            policy.reset()
+    if policy is not None:
+        policy.reset()
 
 
 def reset_environment(robot, events, reset_time_s, fps):


### PR DESCRIPTION
This PR fixes a minor but important bug where policy.reset() was incorrectly called at the end of each step instead of at the end of each episode during evaluation.

- Corrected the indentation so that policy.reset() is now called once per episode.
- This improves the quality and consistency of evaluation, especially when using techniques like temporal ensembling that rely on episode-level resets.

This change ensures proper policy behavior and more reliable evaluation metrics.