### PR TITLE
Fix: Pin `datasets` dependency to `>=2.19.0,<=3.6.0` to maintain compatibility with LeRobot and avoid tensor stacking errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 ]
 dependencies = [
     "cmake>=3.29.0.1",
-    "datasets>=2.19.0",
+    "datasets>=2.19.0,<=3.6.0",
     "deepdiff>=7.0.1",
     "diffusers>=0.27.2",
     "draccus==0.10.0",


### PR DESCRIPTION
#### Context

The Hugging Face `datasets` library introduced a breaking change in versions above `3.6.0` that affects how certain fields (e.g., `timestamp`) are returned—shifting from Python `list`-like behavior to `datasets.Column` objects. This causes incompatibility with the `LeRobotDataset` class, which expects `self.hf_dataset["timestamp"]` to be a list of tensors compatible with `torch.stack()`.

This results in the following runtime error:

```
TypeError: stack(): argument 'tensors' (position 1) must be tuple of Tensors, not Column
```

#### What this PR does

* Pins the `datasets` dependency to `>=2.19.0,<=3.6.0`, aligning with the expected version range used by the latest commits in the [[Hugging Face LeRobot repository](https://github.com/huggingface/lerobot)](https://github.com/huggingface/lerobot)
* Ensures consistent and predictable behavior for dataset loading and recording across environments
* Prevents the runtime mismatch when stacking tensors (e.g., `torch.stack(self.hf_dataset["timestamp"])`)

#### Important Note

* This fix **will not be compatible** with datasets recorded using `datasets>=3.6.0`, due to internal structural differences in the dataset representation.
* **Recommended Action:** Users should start a new data collection session using this pinned `datasets` version to ensure format consistency with `LeRobotDataset`.


Closes #46 