### PR TITLE
Fix reset_environment error when using trossen_ai_mobile without leader arms

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -291,7 +291,7 @@ def reset_environment(robot, events, reset_time_s, fps):
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
 
-    if robot.robot_type in ["trossen_ai_stationary", "trossen_ai_solo"]:
+    if robot.robot_type in ["trossen_ai_stationary", "trossen_ai_solo", "trossen_ai_mobile"]:
         time.sleep(reset_time_s)
     else:
         control_loop(


### PR DESCRIPTION
**PR Description:**

This PR updates the `reset_environment()` function to prevent errors during evaluation with `trossen_ai_mobile`.

* Added `"trossen_ai_mobile"` to the list of robot types that bypass the `control_loop()` during reset.
* This avoids calling `teleop_step()`, which requires leader arms. Since leader arms are disabled during evaluation, this previously resulted in runtime errors.
* Similar handling already exists for `trossen_ai_solo` and `trossen_ai_stationary`; this change ensures consistency across all Trossen robot types.

This fix allows policy evaluation and replay to run correctly on `trossen_ai_mobile` without requiring the leader arms.
