### PR TITLE
Replace version compatibility error with a warning

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -31,7 +31,7 @@ from huggingface_hub.constants import REPOCARD_NAME
 from huggingface_hub.errors import RevisionNotFoundError
 
 from lerobot.common.constants import HF_LEROBOT_HOME
-from lerobot.common.datasets.backward_compatibility import SubVersionBackwardCompatibilityError
+from lerobot.common.datasets.backward_compatibility import SubVersionBackwardCompatibilityError,TROSSEN_V1_MESSAGE #added TROSSEN_V1_MESSAGE
 from lerobot.common.datasets.compute_stats import aggregate_stats, compute_episode_stats
 from lerobot.common.datasets.image_writer import AsyncImageWriter, write_image
 from lerobot.common.datasets.utils import (
@@ -110,7 +110,7 @@ class LeRobotDatasetMetadata:
         if not self.edit_mode:
             check_version_compatibility(self.repo_id, self._version, CODEBASE_VERSION)
             check_version_compatibility(
-                self.repo_id, self._subversion, TROSSEN_SUBVERSION, is_subversion=True
+                self.repo_id, self._subversion, TROSSEN_SUBVERSION, is_subversion=True, enforce_breaking_major = False #added enforce_breaking_major = False
             )
         self.tasks, self.task_to_task_index = load_tasks(self.root)
         self.episodes = load_episodes(self.root)
@@ -144,7 +144,9 @@ class LeRobotDatasetMetadata:
     def _subversion(self) -> packaging.version.Version:
         """Trossen subversion used to create this dataset."""
         if "trossen_subversion" not in self.info:
-            raise SubVersionBackwardCompatibilityError(self.repo_id, "v0.0")
+            #raise SubVersionBackwardCompatibilityError(self.repo_id, "v0.0") #no longer raise error
+            logging.warning(TROSSEN_V1_MESSAGE.format(repo_id=self.repo_id, version="v0.0")) #warning instead
+            return packaging.version.parse("v0.0") # return a default version instead of raising error                                           #anr added
         sub_version = self.info["trossen_subversion"]
         return packaging.version.parse(sub_version)
 


### PR DESCRIPTION
Fix: improve version compatibility for older datasets

## Changes in `lerobot/common/datasets/lerobot_dataset.py`:
- Add `TROSSEN_V1_MESSAGE` import from `backward_compatibility` module (line 34)
- Add `enforce_breaking_major=False` to bypass strict version checking (line 113)  
- Replace `SubVersionBackwardCompatibilityError` with warning message using `logging.warning()` (lines 147+)
- Return default version `v0.0` instead of raising error when subversion metadata is missing
- Allows working with older sample datasets so examples continue to function

## What this does
Fixes crashes when using older datasets that lack `trossen_subversion` metadata. Previously, `visualize_dataset.py` and `train.py` would error and exit when encountering version mismatches. Now they display a warning and continue working, making it possible to try out the examples and build on them for further testing and development.

This enables backward compatibility with existing datasets while maintaining version awareness through warning messages.

**Label**: (🐛 Bug)

## How it was tested
**Before fix**: Both commands crashed with `SubVersionBackwardCompatibilityError`  
**After fix**: Both commands show warning and continue successfully

Tested scenarios:
- Datasets with missing `trossen_subversion` metadata
- Cross-version dataset compatibility  
- Verified existing functionality remains unchanged

## How to checkout & try? (for the reviewer)
Test with older datasets that previously caused crashes:

```bash
# Visualize older dataset (should show warning, not crash)
python lerobot/scripts/visualize_dataset.py \
    --repo-id lerobot/pusht \
    --episode-index 0
python lerobot/scripts/visualize_dataset.py \
    --repo-id lerobot/aloha_sim_transfer_cube_human \
    --episode-index 0

Train with older dataset (should show warning, not crash)  
python lerobot/scripts/train.py \
    --dataset.repo_id=lerobot/aloha_sim_transfer_cube_human \
    --policy.type=act \
    --output_dir=outputs/train/act_aloha_transfer_test8 \
    --env.type=aloha \
    --env.task=AlohaTransferCube-v0 \
    --policy.device=cuda
