### PR TITLE
Fix missing type variable in policy confg.json file after training

### DIFF
--- a/lerobot/common/policies/act/configuration_act.py
+++ b/lerobot/common/policies/act/configuration_act.py
@@ -91,6 +91,7 @@ class ACTConfig(PreTrainedConfig):
     """
 
     # Input / output structure.
+    type: str = "act"
     n_obs_steps: int = 1
     chunk_size: int = 100
     n_action_steps: int = 100

--- a/lerobot/common/policies/diffusion/configuration_diffusion.py
+++ b/lerobot/common/policies/diffusion/configuration_diffusion.py
@@ -104,6 +104,7 @@ class DiffusionConfig(PreTrainedConfig):
     """
 
     # Inputs / output structure.
+    type: str = "diffusion"
     n_obs_steps: int = 2
     horizon: int = 16
     n_action_steps: int = 8


### PR DESCRIPTION
## What this does
Fixes: when using train.py or, for example, 3_train_policy.py on either a real robot database or a simulated database, the output policy config.json file is missing the policy type line, such as "type": "act". When an evaluation script, such as eval.py or 2_evaluate_pretrained_policy.py tries to read the config.json file it fails with an error: 
ParsingError(f"Expected a dict with a '{CHOICE_TYPE_KEY}' key for {cls}, got {raw_value}").

**Label**: (🐛 Bug)

To fix:
In `lerobot/common/policies/act/configuration_act.py`:
- Add type: str = "act" (line 94) to class ACTConfig(PreTrainedConfig):

In `lerobot/common/policies/diffusion/configuration_diffusion.py`:
- Add type: str = "diffusion" (line 107) to class DiffusionConfig(PreTrainedConfig):
 
## How it was tested
**Before fix**: Evaluating a learned policy, e.g. using [eval.py](http://eval.py/) gave ParsingError(f"Expected a dict with a '{CHOICE_TYPE_KEY}' key for {cls}, got {raw_value}") and exited.

**After fix**: No errors when evaluating, e.g. using eval.py.

Tested scenarios:
- Training a policy from a real robot dataset using [train.py](http://train.py/) then evaluating using eval.py.
- Training a policy from a simulated dataset using, e.g. 3_train_policy.py and then evaluating using 2_evaluate_pretrained_policy.py.

## How to checkout & try? (for the reviewer)
Test with the pushT example scripts:

```bash
python examples/3_train_policy.py
python examples/2_evaluate_pretrained_policy.py

# Will fail with ParsingError:

ParsingError(f"Expected a dict with a '{CHOICE_TYPE_KEY}' key for {cls}, got {raw_value}")
and config.json in "outputs/train/example_pusht_diffusion" will be missing 
"type": "diffusion"

Check that config.json in "outputs/train/example_pusht_diffusion" contains "type": "diffusion".
Without fixes they will not. With fixes, they will.