### PR TITLE
feat: Add operator info to metadata (info.json)

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -239,7 +239,7 @@ class LeRobotDatasetMetadata:
     @property
     def operator(self) -> list[dict] | None:
         """List of operators (each as a dict with 'name' and 'email') used in recording this dataset."""
-        return self.info.get("operator")
+        return self.info.get("operator", [])
 
     def update_operator(self, name: str, email: str) -> None:
         """Append a new operator (name and email) to the list of operators used in recording this dataset."""

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -254,7 +254,13 @@ class LeRobotDatasetMetadata:
             operator_entry["email"] = email
         if "operator" not in self.info or not isinstance(self.info["operator"], list):
             self.info["operator"] = []
-        self.info["operator"].append(operator_entry)
+        # Check if operator with the same name already exists
+        for op in self.info["operator"]:
+            if op["name"] == name:
+                op["email"] = email
+                break
+        else:
+            self.info["operator"].append(operator_entry)
         write_info(self.info, self.root)
 
     def get_task_index(self, task: str) -> int | None:

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -237,9 +237,9 @@ class LeRobotDatasetMetadata:
         return self.info["chunks_size"]
     
     @property
-    def operator(self) -> str | None:
-        """Operator used in recording this dataset."""
-        return self.info["operator"]
+    def operator(self) -> list[dict] | None:
+        """List of operators (each as a dict with 'name' and 'email') used in recording this dataset."""
+        return self.info.get("operator")
 
     def update_operator(self, name: str, email: str) -> None:
         """Append a new operator (name and email) to the list of operators used in recording this dataset."""
@@ -247,7 +247,6 @@ class LeRobotDatasetMetadata:
         if "operator" not in self.info or not isinstance(self.info["operator"], list):
             self.info["operator"] = []
         self.info["operator"].append(operator_entry)
-        print(f"Added new operator: {operator_entry}")
         write_info(self.info, self.root)
 
     def get_task_index(self, task: str) -> int | None:

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 import contextlib
 import logging
+import re
 import shutil
 from pathlib import Path
 from typing import Callable
@@ -241,12 +242,16 @@ class LeRobotDatasetMetadata:
         """List of operators (each as a dict with 'name' and 'email') used in recording this dataset. Returns an empty list if no operators are present."""
         return self.info.get("operator", [])
 
-    def update_operator(self, name: str, email: str) -> None:
-        """Append a new operator (name and email) to the list of operators used in recording this dataset."""
-        # Check if name is non-empty and email is in correct format
-        if not name or not isinstance(email, str) or "@" not in email:
-            raise ValueError("Invalid operator name or email.")
-        operator_entry = {"name": name, "email": email}
+    def update_operator(self, name: str, email: str | None = None) -> None:
+        """Append a new operator (name and optional email) to the list of operators used in recording this dataset."""
+        if not isinstance(name, str) or not name:
+            raise ValueError("Operator name must be a non-empty string.")
+        operator_entry = {"name": name}
+        if email is not None:
+            email_regex = r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$"
+            if not isinstance(email, str) or not re.match(email_regex, email):
+                raise ValueError(f"Invalid email format. {email}")
+            operator_entry["email"] = email
         if "operator" not in self.info or not isinstance(self.info["operator"], list):
             self.info["operator"] = []
         self.info["operator"].append(operator_entry)

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -257,7 +257,8 @@ class LeRobotDatasetMetadata:
         # Check if operator with the same name already exists
         for op in self.info["operator"]:
             if op["name"] == name:
-                op["email"] = email
+                if email is not None:
+                    op["email"] = email
                 break
         else:
             self.info["operator"].append(operator_entry)

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -235,6 +235,20 @@ class LeRobotDatasetMetadata:
     def chunks_size(self) -> int:
         """Max number of episodes per chunk."""
         return self.info["chunks_size"]
+    
+    @property
+    def operator(self) -> str | None:
+        """Operator used in recording this dataset."""
+        return self.info["operator"]
+
+    def update_operator(self, name: str, email: str) -> None:
+        """Append a new operator (name and email) to the list of operators used in recording this dataset."""
+        operator_entry = {"name": name, "email": email}
+        if "operator" not in self.info or not isinstance(self.info["operator"], list):
+            self.info["operator"] = []
+        self.info["operator"].append(operator_entry)
+        print(f"Added new operator: {operator_entry}")
+        write_info(self.info, self.root)
 
     def get_task_index(self, task: str) -> int | None:
         """

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -237,12 +237,15 @@ class LeRobotDatasetMetadata:
         return self.info["chunks_size"]
     
     @property
-    def operator(self) -> list[dict] | None:
-        """List of operators (each as a dict with 'name' and 'email') used in recording this dataset."""
+    def operator(self) -> list[dict]:
+        """List of operators (each as a dict with 'name' and 'email') used in recording this dataset. Returns an empty list if no operators are present."""
         return self.info.get("operator", [])
 
     def update_operator(self, name: str, email: str) -> None:
         """Append a new operator (name and email) to the list of operators used in recording this dataset."""
+        # Check if name is non-empty and email is in correct format
+        if not name or not isinstance(email, str) or "@" not in email:
+            raise ValueError("Invalid operator name or email.")
         operator_entry = {"name": name, "email": email}
         if "operator" not in self.info or not isinstance(self.info["operator"], list):
             self.info["operator"] = []


### PR DESCRIPTION
## Pull Request Overview

This PR adds operator information tracking to the LeRobot dataset metadata system. It introduces functionality to store and manage information about operators who record datasets.

- Adds a new `operator` property to access operator information from dataset metadata
- Implements an `update_operator` method to append new operator entries with name and email
- Stores operator data in the dataset's info.json file
