### PR TITLE
Fix TypeError in LeRobotDataset initialization when using --control.resume=true flag

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -557,8 +557,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.episode_data_index = get_episode_data_index(self.meta.episodes, self.episodes)
 
         # Check timestamps
-        timestamps = torch.stack(self.hf_dataset["timestamp"]).numpy()
-        episode_indices = torch.stack(self.hf_dataset["episode_index"]).numpy()
+        timestamps = torch.tensor(self.hf_dataset["timestamp"]).numpy()
+        episode_indices = torch.tensor(self.hf_dataset["episode_index"]).numpy()
         ep_data_index_np = {k: t.numpy() for k, t in self.episode_data_index.items()}
         check_timestamps_sync(timestamps, episode_indices, ep_data_index_np, self.fps, self.tolerance_s)
 


### PR DESCRIPTION
## What this does

Fixes TypeError in LeRobotDataset initialization when using `--control.resume=true` flag. (🐛 Bug)
The current code incorrectly uses torch.stack() on single tensor objects in lines 560-561 of /lerobot/common/datasets/lerobot_dataset.py, causing:

TypeError: stack(): argument 'tensors' (position 1) must be tuple of Tensors, not Tensor
TypeError: stack(): argument 'tensors' (position 1) must be tuple of Tensors, not Column

**Root cause:** torch.stack() requires a sequence of tensors as input, but the code was passing individual tensors/columns.
Solution: Removed unnecessary torch.stack() calls since the data is already in the correct tensor format:

**Before:**
```python
pythontimestamps = torch.stack(torch.tensor(self.hf_dataset["timestamp"])).numpy()
episode_indices = torch.stack(self.hf_dataset["episode_index"]).numpy()
```
After:
```python
pythontimestamps = torch.tensor(self.hf_dataset["timestamp"]).numpy()
episode_indices = torch.tensor(self.hf_dataset["episode_index"]).numpy()
```

## How it was tested

- Reproduced the original error using the exact command from the documentation. Confirmed that no error occurs without  --control.resume flag
- Applied the fix and verified it resolves the TypeError
- Tested complete data collection workflow with --control.resume=true flag
- Confirmed successful dataset upload to Hugging Face repository
- Verified no regression in normal recording functionality (without resume flag)

**Test environment:** Trossen Stationary AI running lerobot via HuggingFace.

## How to checkout & try? (for the reviewer)

**1. Reproduce the original error (on code before this fix):**

```bash
python lerobot/scripts/control_robot.py \
--robot.type=trossen_ai_stationary \
--robot.max_relative_target=null \
--control.type=record \
--control.fps=30 \
--control.single_task="Test recording episode using Trossen AI Stationary." \
--control.repo_id=${HF_USER}/test_dataset \
--control.tags='["tutorial"]' \
--control.warmup_time_s=5 \
--control.episode_time_s=30 \
--control.reset_time_s=30 \
--control.num_episodes=2 \
--control.push_to_hub=true \
--control.resume=true

```

**2. Verify the fix works (with this PR's changes):**

```bash
# Same command as above - should now run without TypeError
```

**3. Check the specific fix:**

```bash
# Verify the problematic lines are fixed
grep -n -A 1 -B 1 "torch.tensor.*timestamp" lerobot/common/datasets/lerobot_dataset.py

```