### PR TITLE
Add batch video encoding with configurable save interval

### DIFF
--- a/examples/12_use_trossen_ai.md
+++ b/examples/12_use_trossen_ai.md
@@ -99,13 +99,13 @@ python lerobot/scripts/control_robot.py \
   --control.type=record \
   --control.fps=30 \
   --control.single_task="Grasp a lego block and put it in the bin." \
-  --control.repo_id=TrossenRoboticsCommunity/trossen_ai_stationary_test_00 \
+  --control.repo_id=${HF_USER}/trossen_ai_stationary_test \
   --control.tags='["tutorial"]' \
-  --control.warmup_time_s=2 \
-  --control.episode_time_s=5 \
-  --control.reset_time_s=2 \
-  --control.num_episodes=6 \
-  --control.push_to_hub=false \
+  --control.warmup_time_s=5 \
+  --control.episode_time_s=30 \
+  --control.reset_time_s=30 \
+  --control.num_episodes=2 \
+  --control.push_to_hub=true \
   --control.num_image_writer_threads_per_camera=8
 ```
 
@@ -119,7 +119,7 @@ echo ${HF_USER}/trossen_ai_stationary_test
 If you didn't upload with `--control.push_to_hub=false`, you can also visualize it locally with:
 ```bash
 python lerobot/scripts/visualize_dataset_html.py \
-  --repo-id TrossenRoboticsCommunity/trossen_ai_stationary_test_00
+  --repo-id ${HF_USER}/trossen_ai_stationary_test
 ```
 
 ## Replay an episode
@@ -132,7 +132,7 @@ python lerobot/scripts/control_robot.py \
   --robot.max_relative_target=null \
   --control.type=replay \
   --control.fps=30 \
-  --control.repo_id=TrossenRoboticsCommunity/trossen_ai_stationary_block_stacking \
+  --control.repo_id=${HF_USER}/trossen_ai_stationary_test \
   --control.episode=0
 ```
 

--- a/examples/12_use_trossen_ai.md
+++ b/examples/12_use_trossen_ai.md
@@ -99,13 +99,13 @@ python lerobot/scripts/control_robot.py \
   --control.type=record \
   --control.fps=30 \
   --control.single_task="Grasp a lego block and put it in the bin." \
-  --control.repo_id=${HF_USER}/trossen_ai_stationary_test \
+  --control.repo_id=TrossenRoboticsCommunity/trossen_ai_stationary_test_00 \
   --control.tags='["tutorial"]' \
-  --control.warmup_time_s=5 \
-  --control.episode_time_s=30 \
-  --control.reset_time_s=30 \
-  --control.num_episodes=2 \
-  --control.push_to_hub=true \
+  --control.warmup_time_s=2 \
+  --control.episode_time_s=5 \
+  --control.reset_time_s=2 \
+  --control.num_episodes=6 \
+  --control.push_to_hub=false \
   --control.num_image_writer_threads_per_camera=8
 ```
 
@@ -119,7 +119,7 @@ echo ${HF_USER}/trossen_ai_stationary_test
 If you didn't upload with `--control.push_to_hub=false`, you can also visualize it locally with:
 ```bash
 python lerobot/scripts/visualize_dataset_html.py \
-  --repo-id ${HF_USER}/trossen_ai_stationary_test
+  --repo-id TrossenRoboticsCommunity/trossen_ai_stationary_test_00
 ```
 
 ## Replay an episode
@@ -132,7 +132,7 @@ python lerobot/scripts/control_robot.py \
   --robot.max_relative_target=null \
   --control.type=replay \
   --control.fps=30 \
-  --control.repo_id=${HF_USER}/trossen_ai_stationary_test \
+  --control.repo_id=TrossenRoboticsCommunity/trossen_ai_stationary_block_stacking \
   --control.episode=0
 ```
 

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -894,15 +894,14 @@ class LeRobotDataset(torch.utils.data.Dataset):
         episode_idx = self.meta.total_episodes + len(self.episode_batch)
         self.episode_buffer = self.create_episode_buffer(episode_index=episode_idx)
 
-    def save_episode_batch(self, episode_data: dict | None = None) -> None:
+    def save_episode_batch(self) -> None:
         """
-        This will save to disk the current episode in self.episode_buffer.
+        This will save to disk all the episodes in self.episode_batch. After saving, the episode_batch
+        will be cleared. Note that this requires self.episode_batch to be non-empty.
+        """
+        if not self.episode_batch:
+            raise ValueError("No episodes to save.")
 
-        Args:
-            episode_data (dict | None, optional): Dict containing the episode data to save. If None, this will
-                save the current episode in self.episode_buffer, which is filled with 'add_frame'. Defaults to
-                None.
-        """
         for episode_buffer in self.episode_batch:
             validate_episode_buffer(episode_buffer, self.meta.total_episodes, self.features)
 

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -529,6 +529,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.image_writer = None
         self.episode_buffer = None
 
+        # Save all episodes in a buffer before writing them to disk and encoding videos
+        self.episode_batch = []
+
         self.root.mkdir(exist_ok=True, parents=True)
 
         # Load metadata
@@ -884,6 +887,87 @@ class LeRobotDataset(torch.utils.data.Dataset):
 
         self.episode_buffer["size"] += 1
 
+    def add_episode_to_batch(self, episode_data: dict | None = None) -> None:
+        if episode_data is None:
+            episode_data = self.episode_buffer
+        self.episode_batch.append(episode_data)
+        episode_idx = self.meta.total_episodes + len(self.episode_batch)
+        self.episode_buffer = self.create_episode_buffer(episode_index=episode_idx)
+
+    def save_episode_batch(self, episode_data: dict | None = None) -> None:
+        """
+        This will save to disk the current episode in self.episode_buffer.
+
+        Args:
+            episode_data (dict | None, optional): Dict containing the episode data to save. If None, this will
+                save the current episode in self.episode_buffer, which is filled with 'add_frame'. Defaults to
+                None.
+        """
+        for episode_buffer in self.episode_batch:
+            validate_episode_buffer(episode_buffer, self.meta.total_episodes, self.features)
+
+            # size and task are special cases that won't be added to hf_dataset
+            episode_length = episode_buffer.pop("size")
+            tasks = episode_buffer.pop("task")
+            episode_tasks = list(set(tasks))
+            episode_index = episode_buffer["episode_index"]
+
+            episode_buffer["index"] = np.arange(self.meta.total_frames, self.meta.total_frames + episode_length)
+            episode_buffer["episode_index"] = np.full((episode_length,), episode_index)
+
+            # Add new tasks to the tasks dictionary
+            for task in episode_tasks:
+                task_index = self.meta.get_task_index(task)
+                if task_index is None:
+                    self.meta.add_task(task)
+
+            # Given tasks in natural language, find their corresponding task indices
+            episode_buffer["task_index"] = np.array([self.meta.get_task_index(task) for task in tasks])
+
+            for key, ft in self.features.items():
+                # index, episode_index, task_index are already processed above, and image and video
+                # are processed separately by storing image path and frame info as meta data
+                if key in ["index", "episode_index", "task_index"] or ft["dtype"] in ["image", "video"]:
+                    continue
+                episode_buffer[key] = np.stack(episode_buffer[key])
+
+            self._wait_image_writer()
+            self._save_episode_table(episode_buffer, episode_index)
+            ep_stats = compute_episode_stats(episode_buffer, self.features)
+
+            if len(self.meta.video_keys) > 0:
+                video_paths = self.encode_episode_videos(episode_index)
+                for key in self.meta.video_keys:
+                    episode_buffer[key] = video_paths[key]
+
+            # `meta.save_episode` be executed after encoding the videos
+            self.meta.save_episode(episode_index, episode_length, episode_tasks, ep_stats)
+
+            ep_data_index = get_episode_data_index(self.meta.episodes, [episode_index])
+            ep_data_index_np = {k: t.numpy() for k, t in ep_data_index.items()}
+            check_timestamps_sync(
+                episode_buffer["timestamp"],
+                episode_buffer["episode_index"],
+                ep_data_index_np,
+                self.fps,
+                self.tolerance_s,
+            )
+
+            video_files = list(self.root.rglob("*.mp4"))
+            assert len(video_files) == self.num_episodes * len(self.meta.video_keys)
+
+            parquet_files = list(self.root.rglob("*.parquet"))
+            assert len(parquet_files) == self.num_episodes
+
+        # delete images
+        img_dir = self.root / "images"
+        if img_dir.is_dir():
+            shutil.rmtree(self.root / "images")
+
+        # Clear the episode batch after saving
+        self.episode_batch = []
+
+
     def save_episode(self, episode_data: dict | None = None) -> None:
         """
         This will save to disk the current episode in self.episode_buffer.
@@ -1073,6 +1157,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
 
         # TODO(aliberts, rcadene, alexander-soare): Merge this with OnlineBuffer/DataBuffer
         obj.episode_buffer = obj.create_episode_buffer()
+
+        obj.episode_batch = []
 
         obj.episodes = None
         obj.hf_dataset = obj.create_hf_dataset()

--- a/lerobot/common/robot_devices/control_configs.py
+++ b/lerobot/common/robot_devices/control_configs.py
@@ -88,7 +88,7 @@ class RecordControlConfig(ControlConfig):
     # Resume recording on an existing dataset.
     resume: bool = False
     # Interval (in number of episodes) to save a checkpoint of the dataset.
-    save_interval: int = 10
+    save_interval: int = 1
 
     def __post_init__(self):
         # HACK: We parse again the cli args here to get the pretrained path if there was one.

--- a/lerobot/common/robot_devices/control_configs.py
+++ b/lerobot/common/robot_devices/control_configs.py
@@ -87,6 +87,8 @@ class RecordControlConfig(ControlConfig):
     play_sounds: bool = True
     # Resume recording on an existing dataset.
     resume: bool = False
+    # Interval (in number of episodes) to save a checkpoint of the dataset.
+    save_interval: int = 10
 
     def __post_init__(self):
         # HACK: We parse again the cli args here to get the pretrained path if there was one.

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -242,6 +242,7 @@ def record(
     cfg: RecordControlConfig,
 ) -> LeRobotDataset:
     # TODO(rcadene): Add option to record logs
+
     if cfg.resume:
         dataset = LeRobotDataset(
             cfg.repo_id,
@@ -323,9 +324,14 @@ def record(
             events["exit_early"] = False
             dataset.clear_episode_buffer()
             continue
+        
+        dataset.add_episode_to_batch()
 
-        dataset.save_episode()
         recorded_episodes += 1
+
+        if recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
+            log_say("Encoding and saving dataset batch...", cfg.play_sounds)
+            dataset.save_episode_batch()
 
         if events["stop_recording"]:
             break

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -329,7 +329,7 @@ def record(
 
         recorded_episodes += 1
 
-        if cfg.save_interval>0 and recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
+        if cfg.save_interval > 0 and recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
             log_say("Encoding and saving dataset batch...", cfg.play_sounds)
             dataset.save_episode_batch()
 

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -329,7 +329,7 @@ def record(
 
         recorded_episodes += 1
 
-        if recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
+        if cfg.save_interval>0 and recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
             log_say("Encoding and saving dataset batch...", cfg.play_sounds)
             dataset.save_episode_batch()
 
@@ -338,6 +338,10 @@ def record(
 
     log_say("Stop recording", cfg.play_sounds, blocking=True)
     stop_recording(robot, listener, cfg.display_cameras)
+
+    if cfg.save_interval<0:
+        log_say("Encoding and saving dataset batch...", cfg.play_sounds)
+        dataset.save_episode_batch()
 
     if cfg.push_to_hub:
         dataset.push_to_hub(tags=cfg.tags, private=cfg.private)

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -339,7 +339,7 @@ def record(
     log_say("Stop recording", cfg.play_sounds, blocking=True)
     stop_recording(robot, listener, cfg.display_cameras)
 
-    if cfg.save_interval<0:
+    if cfg.save_interval<0 or (recorded_episodes % cfg.save_interval != 0):
         log_say("Encoding and saving dataset batch...", cfg.play_sounds)
         dataset.save_episode_batch()
 

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -329,7 +329,7 @@ def record(
 
         recorded_episodes += 1
 
-        if cfg.save_interval > 0 and recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
+        if cfg.save_interval > 0 and cfg.save_interval != 0 and recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
             log_say("Encoding and saving dataset batch...", cfg.play_sounds)
             dataset.save_episode_batch()
 
@@ -339,7 +339,7 @@ def record(
     log_say("Stop recording", cfg.play_sounds, blocking=True)
     stop_recording(robot, listener, cfg.display_cameras)
 
-    if cfg.save_interval<0 or (recorded_episodes % cfg.save_interval != 0):
+    if cfg.save_interval <= 0 or (recorded_episodes % cfg.save_interval != 0):
         log_say("Encoding and saving dataset batch...", cfg.play_sounds)
         dataset.save_episode_batch()
 


### PR DESCRIPTION
This PR introduces support for **batch video encoding** during data collection.

* A new flag `--control.save_interval` allows users to specify how often episodes are encoded and written to disk.
* By default, `save_interval=1`, meaning encoding is performed after every episode.
* Setting `save_interval=-1` , `save_interval=0`  or `save_interval>total recorded episodes` defers encoding until the end of the entire recording session.
* Episodes are encoded and saved in batches, improving flexibility for longer sessions and reducing overhead when immediate encoding is not required.

**Example usage:**

```bash
python lerobot/scripts/control_robot.py \
  --robot.type=trossen_ai_stationary \
  --robot.max_relative_target=null \
  --control.type=record \
  --control.fps=30 \
  --control.single_task="Grasp a lego block and put it in the bin." \
  --control.repo_id=TrossenRoboticsCommunity/trossen_ai_stationary_test_00 \
  --control.tags='["tutorial"]' \
  --control.warmup_time_s=2 \
  --control.episode_time_s=5 \
  --control.reset_time_s=2 \
  --control.num_episodes=6 \
  --control.push_to_hub=false \
  --control.num_image_writer_threads_per_camera=8 \
  --control.save_interval=3 \
  --control.resume=true
```

This example will encode and save videos every 3 episodes instead of after each one.
