### PR TITLE
enhancement: add GPU-based video encoding with FFmpeg using environment variable

### DIFF
--- a/lerobot/common/constants.py
+++ b/lerobot/common/constants.py
@@ -38,6 +38,8 @@ SCHEDULER_STATE = "scheduler_state.json"
 default_cache_path = Path(HF_HOME) / "lerobot"
 HF_LEROBOT_HOME = Path(os.getenv("HF_LEROBOT_HOME", default_cache_path)).expanduser()
 
+GPU_ENCODING = os.getenv("LEROBOT_GPU_ENCODING", "0") == "1"
+
 if "LEROBOT_HOME" in os.environ:
     raise ValueError(
         f"You have a 'LEROBOT_HOME' environment variable set to '{os.getenv('LEROBOT_HOME')}'.\n"

--- a/lerobot/common/constants.py
+++ b/lerobot/common/constants.py
@@ -39,6 +39,8 @@ default_cache_path = Path(HF_HOME) / "lerobot"
 HF_LEROBOT_HOME = Path(os.getenv("HF_LEROBOT_HOME", default_cache_path)).expanduser()
 
 GPU_ENCODING = os.getenv("LEROBOT_GPU_ENCODING", "0") == "1"
+GPU_ID = int(os.getenv("LEROBOT_GPU_ID", "0"))
+GOP_SIZE = int(os.getenv("LEROBOT_GOP_SIZE", "30"))
 
 if "LEROBOT_HOME" in os.environ:
     raise ValueError(

--- a/lerobot/common/datasets/video_utils.py
+++ b/lerobot/common/datasets/video_utils.py
@@ -20,6 +20,7 @@ import subprocess
 import warnings
 from collections import OrderedDict
 from dataclasses import dataclass, field
+from  lerobot.common.constants import GPU_ENCODING
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -242,7 +243,6 @@ def decode_video_frames_torchcodec(
     assert len(timestamps) == len(closest_frames)
     return closest_frames
 
-
 def encode_video_frames(
     imgs_dir: Path | str,
     video_path: Path | str,
@@ -255,10 +255,23 @@ def encode_video_frames(
     log_level: str | None = "error",
     overwrite: bool = False,
 ) -> None:
-    """More info on ffmpeg arguments tuning on `benchmark/video/README.md`"""
+    """More info on ffmpeg arguments tuning on `benchmark/video/README.md`
+    Set use_gpu=True to use Nvidia GPU (requires compatible vcodec, e.g. h264_nvenc or hevc_nvenc).
+    """
+
+    # Use env variable to determine if GPU encoding should be used
+    use_gpu = GPU_ENCODING
+    gpu_id = 0
+
     video_path = Path(video_path)
     imgs_dir = Path(imgs_dir)
     video_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # If use_gpu is True, override vcodec to a GPU-compatible codec if not already set
+    if use_gpu:
+        # Only override if user didn't explicitly set a GPU codec
+        if vcodec not in ["h264_nvenc", "hevc_nvenc"]:
+            vcodec = "h264_nvenc"
 
     ffmpeg_args = OrderedDict(
         [
@@ -272,14 +285,23 @@ def encode_video_frames(
 
     if g is not None:
         ffmpeg_args["-g"] = str(g)
+        if use_gpu:
+            ffmpeg_args["-g"] = "30"
 
     if crf is not None:
-        ffmpeg_args["-crf"] = str(crf)
+        # For NVENC, use -cq instead of -crf for quality control
+        if use_gpu and vcodec in ["h264_nvenc", "hevc_nvenc"]:
+            ffmpeg_args["-cq"] = str(crf)
+        else:
+            ffmpeg_args["-crf"] = str(crf)
 
     if fast_decode:
         key = "-svtav1-params" if vcodec == "libsvtav1" else "-tune"
         value = f"fast-decode={fast_decode}" if vcodec == "libsvtav1" else "fastdecode"
         ffmpeg_args[key] = value
+
+    if use_gpu:
+        ffmpeg_args["-gpu"] = str(gpu_id)
 
     if log_level is not None:
         ffmpeg_args["-loglevel"] = str(log_level)
@@ -289,7 +311,6 @@ def encode_video_frames(
         ffmpeg_args.append("-y")
 
     ffmpeg_cmd = ["ffmpeg"] + ffmpeg_args + [str(video_path)]
-    # redirect stdin to subprocess.DEVNULL to prevent reading random keyboard inputs from terminal
     subprocess.run(ffmpeg_cmd, check=True, stdin=subprocess.DEVNULL)
 
     if not video_path.exists():

--- a/lerobot/common/datasets/video_utils.py
+++ b/lerobot/common/datasets/video_utils.py
@@ -20,7 +20,6 @@ import subprocess
 import warnings
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from  lerobot.common.constants import GPU_ENCODING
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -29,6 +28,8 @@ import torch
 import torchvision
 from datasets.features.features import register_feature
 from PIL import Image
+
+from lerobot.common.constants import GOP_SIZE, GPU_ENCODING, GPU_ID
 
 
 def get_safe_default_codec():
@@ -243,6 +244,7 @@ def decode_video_frames_torchcodec(
     assert len(timestamps) == len(closest_frames)
     return closest_frames
 
+
 def encode_video_frames(
     imgs_dir: Path | str,
     video_path: Path | str,
@@ -255,23 +257,15 @@ def encode_video_frames(
     log_level: str | None = "error",
     overwrite: bool = False,
 ) -> None:
-    """More info on ffmpeg arguments tuning on `benchmark/video/README.md`
-    Set use_gpu=True to use Nvidia GPU (requires compatible vcodec, e.g. h264_nvenc or hevc_nvenc).
-    """
+    """More info on ffmpeg arguments tuning on `benchmark/video/README.md`"""
 
     # Use env variable to determine if GPU encoding should be used
     use_gpu = GPU_ENCODING
-    gpu_id = 0
+    gpu_id = GPU_ID
 
     video_path = Path(video_path)
     imgs_dir = Path(imgs_dir)
     video_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # If use_gpu is True, override vcodec to a GPU-compatible codec if not already set
-    if use_gpu:
-        # Only override if user didn't explicitly set a GPU codec
-        if vcodec not in ["h264_nvenc", "hevc_nvenc"]:
-            vcodec = "h264_nvenc"
 
     ffmpeg_args = OrderedDict(
         [
@@ -283,10 +277,23 @@ def encode_video_frames(
         ]
     )
 
+    # If use_gpu is True, override vcodec to a GPU-compatible codec if not already set
+    if use_gpu:
+        # Only override if user didn't explicitly set a GPU codec
+        if vcodec not in ["h264_nvenc", "hevc_nvenc"]:
+            vcodec = "h264_nvenc"
+            ffmpeg_args["-vcodec"] = vcodec
+        ffmpeg_args["-gpu"] = str(gpu_id)
+
     if g is not None:
         ffmpeg_args["-g"] = str(g)
+        # For GPU encoding, the GOP (Group of Pictures) size should be a multiple of the framerate (e.g., 30, 60, 90)
+        # to ensure optimal keyframe placement and compatibility with hardware encoders.
+        # This helps with efficient seeking and decoding on most players and streaming platforms.
+        # The GOP size is 30 by default, which is a good balance for 30fps videos.
+        # You can adjust it by setting the GOP_SIZE environment variable.
         if use_gpu:
-            ffmpeg_args["-g"] = "30"
+            ffmpeg_args["-g"] = str(GOP_SIZE)
 
     if crf is not None:
         # For NVENC, use -cq instead of -crf for quality control
@@ -299,9 +306,6 @@ def encode_video_frames(
         key = "-svtav1-params" if vcodec == "libsvtav1" else "-tune"
         value = f"fast-decode={fast_decode}" if vcodec == "libsvtav1" else "fastdecode"
         ffmpeg_args[key] = value
-
-    if use_gpu:
-        ffmpeg_args["-gpu"] = str(gpu_id)
 
     if log_level is not None:
         ffmpeg_args["-loglevel"] = str(log_level)


### PR DESCRIPTION
### Summary
This PR adds support for GPU-accelerated video encoding in the batch encoding pipeline. 
The feature allows encoding image sequences into videos using NVIDIA’s NVENC codecs when available, 
improving performance during large-scale dataset generation.

### Implementation
- Introduced environment variable `LEROBOT_GPU_ENCODING` to toggle GPU usage:
  - `LEROBOT_GPU_ENCODING=0` → CPU-based encoding (default)
  - `LEROBOT_GPU_ENCODING=1` → GPU-based encoding (requires compatible NVIDIA GPU)
- Updated FFmpeg command to automatically select GPU-compatible codecs (`h264_nvenc` or `hevc_nvenc`)
- Added logic to override parameters like `-cq`, `-gpu`, and GOP (`-g`) for optimal NVENC performance
- Ensured backward compatibility when GPU encoding is disabled

### Example Command
At runtime, the following FFmpeg command is generated for GPU encoding:

```bash
ffmpeg -f image2 -r <fps> -i <path>/frame_%06d.png
-vcodec h264_nvenc -pix_fmt yuv420p -cq <quality> -g 30 -gpu 0 -y <output_video_path>
```


### Impact
This change significantly reduces encoding time for high-resolution datasets and 
enables smoother integration with the UI for faster post-processing.

### Testing
- Tested encoding with and without `LEROBOT_GPU_ENCODING` set
- Verified correct codec selection and output consistency
- Benchmarked performance improvement ( with NVENC on RTX 5090 GPU)

### Notes
Backward-compatible. Requires NVIDIA GPU with NVENC support and compatible FFmpeg build.
