### PR TITLE
Prevent cleanup failure when no episode batch is present

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -900,7 +900,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         will be cleared. Note that this requires self.episode_batch to be non-empty.
         """
         if not self.episode_batch:
-            raise ValueError("No episodes to save.")
+            print("No episodes to save.")
+            return
 
         for episode_buffer in self.episode_batch:
             validate_episode_buffer(episode_buffer, self.meta.total_episodes, self.features)


### PR DESCRIPTION
### **TL;DR**

Avoid raising an exception when no episodes are available to save, ensuring cleanup logic always runs.

### **What changed?**

* Replaced `raise ValueError("No episode to save")` with a log message and early return in `save_episode_batch()`
* Allows the function to safely exit when `episode_batch` is empty

### **Why make this change?**

* `save_episode_batch()` is called from a `finally` block
* Raising an exception inside `finally` prevented subsequent cleanup logic from executing
* This caused UI elements to remain frozen when no episodes were available for encoding
