### PR TITLE
staging logic correction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
 
   ##### Style / Misc. #####
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v4.6.0
     hooks:
       - id: check-added-large-files
       - id: debug-statements
@@ -37,7 +37,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.30.2
+    rev: v1.24.6
     hooks:
       - id: typos
         args: [--force-exclude]
@@ -48,7 +48,7 @@ repos:
     -   id: pyupgrade
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.10
+    rev: v0.6.9
     hooks:
       - id: ruff
         args: [--fix]
@@ -67,7 +67,7 @@ repos:
       - id: zizmor
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.3
+    rev: 1.7.10
     hooks:
     - id: bandit
       args: ["-c", "pyproject.toml"]

--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -290,17 +290,19 @@ def reset_environment(robot, events, reset_time_s, fps):
     # TODO(rcadene): refactor warmup_record and reset_environment
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
-
-    if robot.robot_type in ["trossen_ai_stationary", "trossen_ai_solo", "trossen_ai_mobile"]:
-        time.sleep(reset_time_s)
-    else:
-        control_loop(
-            robot=robot,
-            control_time_s=reset_time_s,
-            events=events,
-            fps=fps,
-            teleoperate=True,
-        )
+    
+    if has_method(robot, "teleop_start"):
+        robot.teleop_start()
+    
+    control_loop(
+        robot=robot,
+        control_time_s=reset_time_s,
+        events=events,
+        fps=fps,
+        teleoperate=True,
+    )
+    if has_method(robot, "teleop_safety_stop"):
+        robot.teleop_safety_stop()
 
 
 def stop_recording(robot, listener, display_cameras):

--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -288,11 +288,11 @@ def control_loop(
 
 def reset_environment(robot, events, reset_time_s, fps):
     # TODO(rcadene): refactor warmup_record and reset_environment
-    if has_method(robot, "teleop_safety_stop"):
-        robot.teleop_safety_stop()
-    
-    if has_method(robot, "teleop_start"):
-        robot.teleop_start()
+    if has_method(robot, "disable_teleoperation"):
+        robot.disable_teleoperation()
+
+    if has_method(robot, "enable_teleoperation"):
+        robot.enable_teleoperation()
     
     control_loop(
         robot=robot,

--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -293,7 +293,7 @@ def reset_environment(robot, events, reset_time_s, fps):
 
     if has_method(robot, "enable_teleoperation"):
         robot.enable_teleoperation()
-    
+
     control_loop(
         robot=robot,
         control_time_s=reset_time_s,

--- a/lerobot/common/robot_devices/robots/manipulator.py
+++ b/lerobot/common/robot_devices/robots/manipulator.py
@@ -238,7 +238,7 @@ class ManipulatorRobot:
                 self.leader_arms[arms].write("Torque_Enable", 0)
             for arms in self.follower_arms:
                 self.follower_arms[arms].write("Torque_Enable", 1)
-    
+
     def disable_teleoperation(self):
         if self.robot_type in ["trossen_ai_stationary", "trossen_ai_solo"]:
             for arms in self.leader_arms:

--- a/lerobot/common/robot_devices/robots/manipulator.py
+++ b/lerobot/common/robot_devices/robots/manipulator.py
@@ -231,6 +231,9 @@ class ManipulatorRobot:
             for arms in self.follower_arms:
                 self.follower_arms[arms].write("Reset", 1)
             time.sleep(2)
+
+    def teleop_start(self):
+        if self.robot_type in ["trossen_ai_stationary", "trossen_ai_solo"]:
             for arms in self.leader_arms:
                 self.leader_arms[arms].write("Torque_Enable", 0)
             for arms in self.follower_arms:

--- a/lerobot/common/robot_devices/robots/manipulator.py
+++ b/lerobot/common/robot_devices/robots/manipulator.py
@@ -232,12 +232,20 @@ class ManipulatorRobot:
                 self.follower_arms[arms].write("Reset", 1)
             time.sleep(2)
 
-    def teleop_start(self):
+    def enable_teleoperation(self):
         if self.robot_type in ["trossen_ai_stationary", "trossen_ai_solo"]:
             for arms in self.leader_arms:
                 self.leader_arms[arms].write("Torque_Enable", 0)
             for arms in self.follower_arms:
                 self.follower_arms[arms].write("Torque_Enable", 1)
+    
+    def disable_teleoperation(self):
+        if self.robot_type in ["trossen_ai_stationary", "trossen_ai_solo"]:
+            for arms in self.leader_arms:
+                self.leader_arms[arms].write("Torque_Enable", 1)
+            for arms in self.follower_arms:
+                self.follower_arms[arms].write("Torque_Enable", 1)
+            time.sleep(1)
 
     def connect(self):
         if self.is_connected:

--- a/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
+++ b/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
@@ -1,5 +1,4 @@
 import time
-from dataclasses import replace
 from typing import Tuple
 
 import numpy as np
@@ -99,11 +98,18 @@ class TrossenAIMobile:
             self.follower_arms[arms].write("Reset", 1)
         time.sleep(2)
 
-    def teleop_start(self):
+    def enable_teleoperation(self):
         for arms in self.leader_arms:
             self.leader_arms[arms].write("Torque_Enable", 0)
         for arms in self.follower_arms:
             self.follower_arms[arms].write("Torque_Enable", 1)
+
+    def disable_teleoperation(self):
+        for arms in self.leader_arms:
+            self.leader_arms[arms].write("Torque_Enable", 1)
+        for arms in self.follower_arms:
+            self.follower_arms[arms].write("Torque_Enable", 1)
+        time.sleep(1)
 
     def connect(self) -> None:
         if self.is_connected:

--- a/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
+++ b/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
@@ -98,6 +98,8 @@ class TrossenAIMobile:
         for arms in self.follower_arms:
             self.follower_arms[arms].write("Reset", 1)
         time.sleep(2)
+
+    def teleop_start(self):
         for arms in self.leader_arms:
             self.leader_arms[arms].write("Torque_Enable", 0)
         for arms in self.follower_arms:

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -328,12 +328,17 @@ def record(
                 events["exit_early"] = False
                 dataset.clear_episode_buffer()
                 continue
-            
+
             dataset.add_episode_to_batch()
 
             recorded_episodes += 1
 
-            if cfg.save_interval > 0 and cfg.save_interval != 0 and recorded_episodes % cfg.save_interval == 0 and recorded_episodes > 0:
+            if (
+                cfg.save_interval > 0
+                and cfg.save_interval != 0
+                and recorded_episodes % cfg.save_interval == 0
+                and recorded_episodes > 0
+            ):
                 log_say("Encoding and saving dataset batch...", cfg.play_sounds)
                 dataset.save_episode_batch()
 
@@ -354,7 +359,9 @@ def record(
         try:
             dataset.save_episode_batch()
         except Exception as save_exc:
-            logging.error(f"Exception occurred while saving dataset in finally block: {save_exc}", exc_info=True)
+            logging.error(
+                f"Exception occurred while saving dataset in finally block: {save_exc}", exc_info=True
+            )
 
     if cfg.push_to_hub:
         dataset.push_to_hub(tags=cfg.tags, private=cfg.private)

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -290,12 +290,17 @@ def record(
 
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
+    if has_method(robot, "teleop_start"):
+        robot.teleop_start()
 
     recorded_episodes = 0
     try:
         while True:
             if recorded_episodes >= cfg.num_episodes:
                 break
+
+            if has_method(robot, "teleop_start"):
+                robot.teleop_start()
 
             log_say(f"Recording episode {dataset.num_episodes}", cfg.play_sounds)
             record_episode(

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -290,8 +290,6 @@ def record(
 
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
-    if has_method(robot, "teleop_start"):
-        robot.teleop_start()
 
     recorded_episodes = 0
     try:
@@ -299,8 +297,8 @@ def record(
             if recorded_episodes >= cfg.num_episodes:
                 break
 
-            if has_method(robot, "teleop_start"):
-                robot.teleop_start()
+            if has_method(robot, "enable_teleoperation"):
+                robot.enable_teleoperation()
 
             log_say(f"Recording episode {dataset.num_episodes}", cfg.play_sounds)
             record_episode(


### PR DESCRIPTION
## What this does
Updated the staging logic during episode recording. Below is a breakdown of the previous logic and current changes.

### Previous Logic (Issue)
1. Episode recording starts
2. Episode recording completed
3. `teleop_safety_stop`
   - Arm goes to its reset position
   - Leader set to torque mode (can be freely moved)
   - Follower set to position mode (cannot be freely moved)
4. Wait for `reset_episode_time`
   - **Issue**: During this time period, if we move the leader arm from reset position, the follower arm will still be at reset position
5. Wait for encoding of episode to complete
   - **Issue**: During this time period, if we move the leader arm from reset position, the follower arm will still be at reset position
6. Start teleoperation (if leader moved during this time, follower command position will be large)
7. Teleoperation starts
8. Recording of next episode starts

### Current Logic (Fixed)
1. Episode recording starts
2. Episode recording completed
3. `teleop_safety_stop`
   - Arm goes to its reset position
4. `teleop_start`
   - Leader set to torque mode (can be freely moved)
   - Follower set to position mode (cannot be freely moved)
5. Wait for `reset_episode_time`
   - **Issue solved**: During this time, teleoperation is active so both arms will move together. This allows moving the gripper to clear objects or adjust the environment during reset time.
6. `teleop_safety_stop`
7. Wait for encoding of episode to complete
   - **Issue solved**: Because teleop is stopped and leader is not in torque mode, we cannot move leader or follower during encoding
8. Start teleoperation
9. `teleop_start`
10. Recording of next episode starts

## How it was tested
Collected two or more episodes. During the reset environment time period, teleoperation is active and both arms move together. After the reset time, during encoding, the leader and follower are locked and cannot move.