### PR TITLE
Remove odometry data from mobile robot state

### DIFF
--- a/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
+++ b/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
@@ -52,7 +52,7 @@ class TrossenAIMobile:
     @property
     def motor_features(self) -> dict:
         action_names = ["linear_vel", "angular_vel"] + self.get_motor_names(self.leader_arms)
-        state_names = ["odom_x", "odom_y", "odom_theta", "linear_vel", "angular_vel"] + self.get_motor_names(
+        state_names = ["linear_vel", "angular_vel"] + self.get_motor_names(
             self.leader_arms
         )
         return {
@@ -193,9 +193,6 @@ class TrossenAIMobile:
             )
         self.base.read(self.slate_base_data)
         return {
-            "odom_x": self.slate_base_data.odom_x,
-            "odom_y": self.slate_base_data.odom_y,
-            "odom_theta": self.slate_base_data.odom_z,
             "linear_vel": self.slate_base_data.vel_x,
             "angular_vel": self.slate_base_data.vel_z,
         }


### PR DESCRIPTION
## **Summary**

Removed odometry position data (`x`, `y`, `theta`) from the Trossen AI Mobile robot state representation, retaining only velocity-based information.

---

## **Changes**

* Removed `"odom_x"`, `"odom_y"`, and `"odom_theta"` from `state_names` in the `motor_features` property
* Removed corresponding odometry readings from the `read_base` method
* Simplified state representation to include only `"linear_vel"` and `"angular_vel"` in addition to arm motor names

---

## **Motivation**

This change was made to:

* Avoid issues related to the odometry mapping bug that caused inconsistencies in state representation
* Standardize the dataset format across all mobile platforms by using a consistent velocity-based base state

---

## **Validation**

The change was validated by:

* Replaying both recorded **actions and observations** from a collected dataset
* Verifying that the robot exhibited identical behavior after the modification

This confirms that the action space remains consistent with the observation space and that removing absolute odometry values does not alter functional behavior.
