### PR TITLE
opencv-python ver < 4.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
     "jsonlines>=4.0.0",
     "numba>=0.59.0",
     "omegaconf>=2.3.0",
-    "opencv-python>=4.9.0",
+    "opencv-python<4.13",
     "packaging>=24.2",
     "av>=12.0.5,<13.0.0",
     "pymunk>=6.6.0",


### PR DESCRIPTION
Do not use opencv-python ver = 4.13 as opencv camera list script not working with 4.13.