### PR TITLE
Fix order of feature names in mobile AI

### DIFF
--- a/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
+++ b/lerobot/common/robot_devices/robots/trossen_ai_mobile.py
@@ -51,10 +51,8 @@ class TrossenAIMobile:
 
     @property
     def motor_features(self) -> dict:
-        action_names = ["linear_vel", "angular_vel"] + self.get_motor_names(self.leader_arms)
-        state_names = ["linear_vel", "angular_vel"] + self.get_motor_names(
-            self.leader_arms
-        )
+        action_names = self.get_motor_names(self.leader_arms) + ["linear_vel", "angular_vel"]
+        state_names = self.get_motor_names(self.leader_arms) + ["linear_vel", "angular_vel"]
         return {
             "action": {
                 "dtype": "float32",


### PR DESCRIPTION
This pull request makes a small adjustment to the order of items in the `action_names` and `state_names` lists within the `motor_features` property of the `trossen_ai_mobile.py` file. The robot's motor names are now listed before the `"linear_vel"` and `"angular_vel"` entries, instead of after. This change may affect code that depends on the order of these features.

- Changed the order of elements in the `action_names` and `state_names` lists in the `motor_features` property so that motor names appear before `"linear_vel"` and `"angular_vel"` (`lerobot/common/robot_devices/robots/trossen_ai_mobile.py`).
