### PR TITLE
Add error recovery for trossen arms

### DIFF
--- a/lerobot/common/robot_devices/motors/trossen_arm_driver.py
+++ b/lerobot/common/robot_devices/motors/trossen_arm_driver.py
@@ -235,11 +235,14 @@ class TrossenArmDriver:
             raise RobotDeviceNotConnectedError(
                 f"TrossenArmDriver ({self.ip}) is not connected. Try running `motors_bus.connect()` first."
             )
+        self.driver.cleanup()
+        model_name, model_end_effector = TROSSEN_ARM_MODELS[self.model]
+        self.driver.configure(model_name, model_end_effector, self.ip, True)
         self.driver.set_all_modes(trossen.Mode.velocity)
         self.driver.set_all_velocities([0.0] * self.driver.get_num_joints(), 0.0, False)
         self.driver.set_all_modes(trossen.Mode.position)
         self.driver.set_all_positions(self.home_pose, 2.0, True)
-        self.driver.set_all_positions(self.sleep_pose, 2.0, False)
+        self.driver.set_all_positions(self.sleep_pose, 2.0, True)
 
         self.is_connected = False
 


### PR DESCRIPTION
This pull request updates the `disconnect` method in `trossen_arm_driver.py` to improve the shutdown sequence for the Trossen arm. The changes ensure the arm is properly reconfigured and moved to the sleep pose in a blocking manner during disconnection.

Improvements to device disconnection and safety:

* Added a call to `self.driver.cleanup()` at the start of the disconnect process to ensure resources are properly released.
* Reconfigured the driver with the model name, end effector, and IP after cleanup to reset the device state.
* Changed the call to `set_all_positions` for the sleep pose to be blocking (`wait=True`), ensuring the arm reaches the sleep position before disconnecting.