### PR TITLE
fix: resolve KeyError 'left' and spurious save error during policy evaluation

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -288,18 +288,24 @@ def control_loop(
 
 def reset_environment(robot, events, reset_time_s, fps):
     # TODO(rcadene): refactor warmup_record and reset_environment
-    if has_method(robot, "disable_teleoperation"):
-        robot.disable_teleoperation()
 
-    if has_method(robot, "enable_teleoperation"):
-        robot.enable_teleoperation()
+    # Leader arms are disabled during policy evaluation (set to empty in control_robot.py).
+    # Only enable teleoperation for the reset period when they are available, i.e. during data collection.
+    has_leader_arms = hasattr(robot, "leader_arms") and len(robot.leader_arms) > 0
+
+    if has_leader_arms:
+        if has_method(robot, "disable_teleoperation"):
+            robot.disable_teleoperation()
+
+        if has_method(robot, "enable_teleoperation"):
+            robot.enable_teleoperation()
 
     control_loop(
         robot=robot,
         control_time_s=reset_time_s,
         events=events,
         fps=fps,
-        teleoperate=True,
+        teleoperate=has_leader_arms,
     )
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -355,13 +355,16 @@ def record(
     except Exception as e:
         logging.error(f"An exception occurred: {e}", exc_info=True)
     finally:
+        # Flush any remaining episodes not yet saved (e.g. a partial batch at the end of recording).
+        # Guard against an empty batch, which would raise "No episodes to save" when already flushed.
         logging.info("Saving dataset...")
-        try:
-            dataset.save_episode_batch()
-        except Exception as save_exc:
-            logging.error(
-                f"Exception occurred while saving dataset in finally block: {save_exc}", exc_info=True
-            )
+        if dataset.episode_batch:
+            try:
+                dataset.save_episode_batch()
+            except Exception as save_exc:
+                logging.error(
+                    f"Exception occurred while saving dataset in finally block: {save_exc}", exc_info=True
+                )
 
     if cfg.push_to_hub:
         dataset.push_to_hub(tags=cfg.tags, private=cfg.private)


### PR DESCRIPTION
Two bugs were triggered when running evaluation (record with a policy):

1. KeyError: 'left' in reset_environment control_robot.py sets robot.leader_arms = [] when a policy is provided, since leader arms are not needed during evaluation. However, reset_environment always called control_loop(teleoperate=True), which invoked teleop_step. teleop_step iterates over follower_arms and tries to look up each arm name in leader_pos (built from leader_arms). With leader_arms empty, leader_pos['left'] raised KeyError: 'left', crashing the recording loop before any episode could be saved.

   Fix: reset_environment now checks whether leader arms are available and only enables teleoperation during the reset period when they are (i.e. during data collection). During evaluation the reset loop runs without teleoperation, simply waiting out the reset_time_s window.

2. Spurious "No episodes to save" error in the finally block The finally block in the record() function is intended to flush any remaining episodes that were not covered by a periodic save_interval batch save. However, it was called unconditionally, including when all episodes had already been saved, resulting in a misleading error log.

   Fix: guard the save_episode_batch() call with a check on dataset.episode_batch so it only runs when there is actually data to flush.
